### PR TITLE
removes `--witness` and always outputs the counterexamples

### DIFF
--- a/src/ic3/mod.rs
+++ b/src/ic3/mod.rs
@@ -524,34 +524,83 @@ impl Engine for IC3 {
         //     b = bad.next.clone();
         // }
         // witness_encode(aig, &res)
-        use std::fmt::Write;
-        let mut res = String::new();
-        let mut bad = self.obligations.peak();
-        if let Some(mut b) = bad {
-            writeln!(&mut res, "Frame 0:").unwrap();
-            for lit in b.lemma.iter() {
-                writeln!(&mut res, "  {}", frame::LitDisplay {
-                    lit,
-                    symbs: &self.symbs,
-                }).unwrap();
+        if self.options.json_output {
+            use serde::Serialize;
+
+            #[derive(Serialize)]
+            struct JsonAssign {
+                name: String,
+                value: bool,
             }
-            bad = b.next.take();
-        }
-        let mut cnt = 1usize;
-        while let Some(mut b) = bad {
-            for inp in b.input.iter() {
-                writeln!(&mut res, "Frame {cnt}:").unwrap();
-                cnt += 1;
-                for lit in inp.iter() {
+
+            let res = {
+                let symbs = &self.symbs;
+                let mut witness = vec![];
+                let mut bad = self.obligations.peak();
+                if let Some(mut b) = bad {
+                    let frame: Vec<_> = b.lemma.iter()
+                        .map(|lit| {
+                            let var = lit.var();
+                            let name = symbs.get(&var).cloned().unwrap_or_else(|| format!("{{{}}}", var));
+                            JsonAssign {
+                                name,
+                                value: lit.polarity(),
+                            }
+                        })
+                        .collect();
+                    witness.push(frame);
+                    bad = b.next.take();
+                }
+                while let Some(mut b) = bad {
+                    for inp in b.input.iter() {
+                        let frame: Vec<_> = inp.iter()
+                            .map(|lit| {
+                                let var = lit.var();
+                                let name = symbs.get(&var).cloned().unwrap_or_else(|| format!("{{{}}}", var));
+                                JsonAssign {
+                                    name,
+                                    value: lit.polarity(),
+                                }
+                            })
+                            .collect();
+                        witness.push(frame);
+                    }
+                    bad = b.next.take();
+                }
+
+                witness
+            };
+            serde_json::to_string(&res).unwrap()
+        } else {
+            use std::fmt::Write;
+            let mut res = String::new();
+            let mut bad = self.obligations.peak();
+            if let Some(mut b) = bad {
+                writeln!(&mut res, "Frame 0:").unwrap();
+                for lit in b.lemma.iter() {
                     writeln!(&mut res, "  {}", frame::LitDisplay {
                         lit,
                         symbs: &self.symbs,
                     }).unwrap();
                 }
+                bad = b.next.take();
             }
-            bad = b.next.take();
+            let mut cnt = 1usize;
+            while let Some(mut b) = bad {
+                for inp in b.input.iter() {
+                    writeln!(&mut res, "Frame {cnt}:").unwrap();
+                    cnt += 1;
+                    for lit in inp.iter() {
+                        writeln!(&mut res, "  {}", frame::LitDisplay {
+                            lit,
+                            symbs: &self.symbs,
+                        }).unwrap();
+                    }
+                }
+                bad = b.next.take();
+            }
+            res
         }
-        res
     }
 
     fn statistic(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,13 +109,10 @@ pub fn certificate(engine: &mut Box<dyn Engine>, aig: &Aig, option: &Options, re
         certifaiger.to_file(certificate_path, true);
         certifaiger_check(option, certificate_path);
     } else {
-        if option.certificate.is_none() && !option.certify && !option.witness {
+        if option.certificate.is_none() && !option.certify {
             return;
         }
         let witness = engine.witness(aig);
-        if option.witness {
-            println!("{}", witness);
-        }
         if let Some(certificate_path) = &option.certificate {
             let mut file: File = File::create(certificate_path).unwrap();
             file.write_all(witness.as_bytes()).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use rIC3::{
     options::{self, Options},
     portfolio::portfolio_main,
     transys::Transys,
+    certificate,
 };
 use jiff::Timestamp;
 use log::*;
@@ -125,18 +126,19 @@ fn raw_main(mut options: Options) -> Option<bool> {
     engine.statistic();
     match res {
         Some(true) => {
-            println!("result: safe");
-            if options.witness {
-                println!("{}", engine.witness(&origin_aig));
+            if !options.json_output {
+                println!("result: safe");
             }
-            // certificate(&mut engine, &origin_aig, &options, true)
+            certificate(&mut engine, &aig, &options, true);
         }
         Some(false) => {
-            println!("result: unsafe");
-            if options.witness {
+            if options.json_output {
+                println!("{}", engine.witness(&origin_aig));
+            } else {
+                println!("result: unsafe");
                 println!("{}", engine.witness(&origin_aig));
             }
-            // certificate(&mut engine, &origin_aig, &options, false)
+            certificate(&mut engine, &aig, &options, false);
         }
         _ => {
             println!("result: unknown");

--- a/src/options.rs
+++ b/src/options.rs
@@ -27,10 +27,6 @@ pub struct Options {
     #[arg(long, default_value_t = false)]
     pub certify: bool,
 
-    /// print witness when model is unsafe
-    #[arg(long, default_value_t = false)]
-    pub witness: bool,
-
     #[command(flatten)]
     pub ic3: IC3Options,
 
@@ -60,6 +56,10 @@ pub struct Options {
     /// By default, no limit at all.
     #[arg(long="timeout")]
     pub timeout: Option<jiff::Span>,
+
+    /// outputs in json format.
+    #[arg(long="json-output")]
+    pub json_output: bool,
 }
 
 #[derive(Copy, Clone, ValueEnum, Debug)]

--- a/src/portfolio.rs
+++ b/src/portfolio.rs
@@ -7,7 +7,7 @@ use std::{
     io::{Read, Write},
     mem::take,
     ops::{Deref, DerefMut},
-    process::{Command, exit},
+    process::{Command, exit, Stdio},
     sync::{Arc, Condvar, Mutex},
     thread::spawn,
 };
@@ -138,9 +138,14 @@ impl Portfolio {
     fn check_inner(&mut self) -> Option<bool> {
         let lock = self.state.0.lock().unwrap();
         for mut engine in take(&mut self.engines) {
+            let config = engine
+                .get_args()
+                .skip(1)
+                .map(|cstr| cstr.to_str().unwrap())
+                .collect::<Vec<&str>>()
+                .join(" ");
             let certificate = if self.option.certificate.is_some()
                 || self.option.certify
-                || self.option.witness
             {
                 let certificate = tempfile::NamedTempFile::new_in(self.temp_dir.path()).unwrap();
                 let certify_path = certificate.path().as_os_str().to_str().unwrap();
@@ -149,17 +154,16 @@ impl Portfolio {
             } else {
                 None
             };
-            let child = engine.spawn().unwrap();
+            let child = {
+                if self.option.json_output {
+                    engine.arg("--json-output");
+                }
+                engine.stdout(Stdio::piped()).spawn().unwrap()
+            };
             self.engine_pids.push(child.id() as i32);
             let state = self.state.clone();
             let timeout = self.option.timeout.clone();
             spawn(move || {
-                let config = engine
-                    .get_args()
-                    .skip(1)
-                    .map(|cstr| cstr.to_str().unwrap())
-                    .collect::<Vec<&str>>();
-                let config = config.join(" ");
                 #[cfg(target_os = "linux")]
                 let output = {
                     let child = child
@@ -263,7 +267,7 @@ fn certificate(engine: &mut Portfolio, option: &Options, res: bool) {
             std::fs::copy(engine.certificate.as_ref().unwrap(), certificate_path).unwrap();
         }
     } else {
-        if option.certificate.is_none() && !option.certify && !option.witness {
+        if option.certificate.is_none() && !option.certify {
             return;
         }
         let mut witness = String::new();
@@ -280,9 +284,6 @@ fn certificate(engine: &mut Portfolio, option: &Options, res: bool) {
         .unwrap()
         .read_to_string(&mut witness)
         .unwrap();
-        if option.witness {
-            println!("{}", witness);
-        }
         if let Some(certificate_path) = &option.certificate {
             let mut file: File = File::create(certificate_path).unwrap();
             file.write_all(witness.as_bytes()).unwrap();


### PR DESCRIPTION
* The portfolio engine outputs whatever the underlying engine outputs.
* The counterexamples can be in json format by specifying the `--json-output` argument.